### PR TITLE
Faculty Links from CSUCI CS Faculty Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # awesome-csuci
 A curated list of awesome projects, research, frameworks, libraries, and software by CSUCI students, faculty, and alumni
+
+## Websites
+Personal websites (blogs, portfolios, ect.) of CSUCI students, faculty, and alumni.
+
+* [Leo Benegas](http://faculty.csuci.edu/leo.benegas/)
+* [Andrzej (A.J.) Bieszczad](http://ajb.cirainbow.csuci.edu/ajb/)
+* [David Claveau](http://faculty.csuci.edu/David.Claveau/)
+* [Houman Dallali](http://www.hdallali.com)
+* [Jason Isaacs](http://isaacs.cs.csuci.edu)
+* [Pawel Pilarczyk](http://www.pawelpilarczyk.com)
+* [Kevin Scrivnor](http://scrivnor.cikeys.com)
+* [Michael Soltys](http://soltys.cs.csuci.edu)
+* [Peter Smith](http://faculty.csuci.edu/peter.smith/)
+* [Brian Thoms](http://www.brianthoms.com)


### PR DESCRIPTION
https://compsci.csuci.edu/about/faculty.htm
It looks like Professor Anna's site is down or something so I did not add that one.
I considered adding Dr. in front of the professor's names but decided against it... maybe we should add it. Thoughts?